### PR TITLE
Fix wrong info displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ jobs:
     steps:
       - uses: AButler/upload-release-assets@v1.0
         with:
-          files: 'artifacts/*,packages/*.nupkg'
+          files: 'artifacts/*;packages/*.nupkg'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Inputs
 
-| Name          | Description                                                                                     | Examples                                                 |
-|---------------|-------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| `files`       | The glob of files to upload (comma-separate multiple globs)                                     | `file.txt` <br> `file*.txt` <br> `file_{a,b}.txt;*.json` |
+| Name          | Description                                                                                       | Examples                                                 |
+|---------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------|
+| `files`       | The glob of files to upload (semicolon separate multiple globs)                                   | `file.txt` <br> `file*.txt` <br> `file_{a,b}.txt;*.json` |
 | `repo-token`  | The GitHub token to use to amend the release _(recommended to use `${{ secrets.GITHUB_TOKEN }}`)_ | `${{ secrets.GITHUB_TOKEN }}`                            |
 | `release-tag` | _(Optional)_ Specify the tag of the release to upload to                                          | `v1.0.0`                                                 |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ jobs:
   build:
     # ...
     steps:
-      - uses: AButler/upload-release-assets@v1.0
+      - uses: AButler/upload-release-assets@v2.0
         with:
           files: 'artifacts/*;packages/*.nupkg'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -23,4 +23,4 @@ jobs:
 |---------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------|
 | `files`       | The glob of files to upload (semicolon separate multiple globs)                                   | `file.txt` <br> `file*.txt` <br> `file_{a,b}.txt;*.json` |
 | `repo-token`  | The GitHub token to use to amend the release _(recommended to use `${{ secrets.GITHUB_TOKEN }}`)_ | `${{ secrets.GITHUB_TOKEN }}`                            |
-| `release-tag` | _(Optional)_ Specify the tag of the release to upload to                                          | `v1.0.0`                                                 |
+| `release-tag` | _(Optional)_ Specify the tag of the release to upload to                                          | `v2.0`                                                   |

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ jobs:
 |---------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------|
 | `files`       | The glob of files to upload (semicolon separate multiple globs)                                   | `file.txt` <br> `file*.txt` <br> `file_{a,b}.txt;*.json` |
 | `repo-token`  | The GitHub token to use to amend the release _(recommended to use `${{ secrets.GITHUB_TOKEN }}`)_ | `${{ secrets.GITHUB_TOKEN }}`                            |
-| `release-tag` | _(Optional)_ Specify the tag of the release to upload to                                          | `v2.0`                                                   |
+| `release-tag` | _(Optional)_ Specify the tag of the release to upload to                                          | `v1.0.0`                                                 |


### PR DESCRIPTION
The README still displayed commas to separate different file names instead of semicolons, which has been corrected with this PR.