### PR TITLE
Dependency Updates

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: 'secrets.GITHUB_TOKEN'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "AButler",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.9.1",
+    "@actions/core": "^1.10.0",
     "@actions/github": "^1.1.0",
     "fast-glob": "^3.0.4",
     "mime-types": "^2.1.24"


### PR DESCRIPTION
On Oct 12, the @actions/core started throwing deprecation notices. The package needs to be updated to v1.10.0. Additionally, the node12 runtime has now been deprecated by Github in favor of node16. This PR provides both updates.

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/770982/195999915-4f221360-56ae-4582-9192-9d62f36aaff1.png">
