### PR TITLE
bump using node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: 'secrets.GITHUB_TOKEN'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/main.js'


### PR DESCRIPTION
trying to address GH warning:
`
The following actions uses node12 which is deprecated and will be forced to run on node16: AButler/upload-release-assets@v2.0. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
`